### PR TITLE
:chore: Update outlook search filters

### DIFF
--- a/browser_test_proving/src/loginWithMicrosoft.ts
+++ b/browser_test_proving/src/loginWithMicrosoft.ts
@@ -8,11 +8,11 @@ export function setupLoginWithMicrosoft(element: HTMLElement) {
   const loginButton = element.querySelector("button");
   if (loginButton) {
     loginButton.addEventListener("click", async () => {
-      const blueprint = await sdk.getBlueprintById("0935faed-002d-4b94-8cbf-476b3b05d9a6");
+      const blueprint = await sdk.getBlueprintById("963fbbe8-7f08-4a9c-8608-f378b144aec3");
       // const blueprint = await sdk.getBlueprintById("008b5da5-fbda-4445-b7df-6b0c6dde4bb1");
       // const blueprint2 = await sdk.getBlueprintById("0935faed-002d-4b94-8cbf-476b3b05d9a6");
 
-      blueprint.props.emailQuery = "from:account-security-noreply@accountprotection.microsoft.com";
+      // blueprint.props.emailQuery = "from:x.com password reset";
 
       // optional - manually start Login with Google flow and authorize before fetching emails
       console.log("Manually authorizing");


### PR DESCRIPTION
Due to `$filter` params, we could not search in the message body. So for the gmail queries like `from:x.com password reset`, it is filtering by this whole string which is not searchable by outlook. In this PR:
- I separated the parts of the query so that we can query for each part individually
- Instead of `$filter`, I updated the logic to use `$search` query param which provide more control over search
- Updated the default number of emails to be fetched