### PR TITLE
docs: add Kusama grant milestone-3 delivery evidence (SDK)

### DIFF
--- a/docs/kusama-grant/README.md
+++ b/docs/kusama-grant/README.md
@@ -1,0 +1,11 @@
+# Kusama Grant Documentation Index
+
+This directory tracks delivery evidence for Kusama grant milestones related to the `@zk-email/sdk` (zk-email-sdk-js) repository.
+
+## Milestones
+
+- Milestone 3 (this repository): [`./milestone-3/00_overview.md`](./milestone-3/00_overview.md)
+
+## Current Status Snapshot
+
+- Milestone 3: `Delivered`

--- a/docs/kusama-grant/milestone-3/00_overview.md
+++ b/docs/kusama-grant/milestone-3/00_overview.md
@@ -1,0 +1,15 @@
+# Milestone 3 - SDK Multi-Chain On-Chain Verification
+
+Primary Goal: Update `@zk-email/sdk` to support on-chain proof verification against PolkaVM/Paseo Testnet in addition to Ethereum Sepolia, using the new `ZKEmailVerifier` ABI, and to stay compatible with `zkemail.nr` v2.0.0 Noir proof output format.
+
+## Deliverables (this repository)
+
+| # | Name | Description | Status |
+| --- | --- | --- | --- |
+| 1 | Multi-Chain On-Chain Verification | Update `verifyProofOnChain` to support Ethereum Sepolia and Paseo Testnet (Polkadot), with new verifier ABI `verify(bytes proof, bytes32[] publicInputs)` and viem-based proof encoding. | `Delivered` |
+| 2 | Noir v2.0.0 Proof Output Compatibility | Update Noir public output parsing and public key verification to match `zkemail.nr` v2.0.0, which adds a `pubkey_redc_hash` output field. | `Delivered` |
+
+## Evidence Index
+
+- [`01_multi_chain_verification.md`](./01_multi_chain_verification.md)
+- [`02_noir_v2_compatibility.md`](./02_noir_v2_compatibility.md)

--- a/docs/kusama-grant/milestone-3/01_multi_chain_verification.md
+++ b/docs/kusama-grant/milestone-3/01_multi_chain_verification.md
@@ -1,0 +1,51 @@
+# 01 - Multi-Chain On-Chain Verification
+
+Deliverable mapping: Milestone 3, Multi-Chain On-Chain Verification.
+
+## What was delivered
+
+`verifyProofOnChain` in [`src/chain/index.ts`](../../../src/chain/index.ts) was rewritten to:
+
+- **Support multiple chains:** Ethereum Sepolia (`11155111`) and Paseo Testnet / Polkadot Hub Testnet (`420420417`). The chain is looked up from `proof.blueprint.props.verifierContract.chain` via a `CHAIN_MAP`.
+- **Use the new verifier ABI:** The on-chain call now targets `verify(bytes proof, bytes32[] publicInputs)` instead of the old `verify(uint8 proofType, uint256[2] a, uint256[2][2] b, uint256[2] c, uint256[N] signals)` interface.
+- **Encode the proof as ABI-packed bytes:** `pA`, `pB` (with coordinate swap), and `pC` are ABI-encoded into a single `bytes` parameter via viem's `encodeAbiParameters`.
+- **Convert public signals to `bytes32[]`:** Each public output is padded to 32 bytes using viem's `toHex`.
+- **Remove `snarkjs` dependency:** The `snarkjs.groth16.exportSolidityCallData` call and the `snarkjs` import were removed; all encoding is now done with viem.
+- **Define Paseo as a custom viem chain:** Chain ID `420420417` is defined using `defineChain` with the Polkadot Hub Testnet RPC URL (`https://services.polkadothub-rpc.com/testnet`).
+
+Base Sepolia (`84532`) was also added back as a supported chain in `CHAIN_MAP`.
+
+## Implementation Notes
+
+- **Chain map:** `CHAIN_MAP: Record<number, Chain>` maps `11155111 → sepolia`, `420420417 → paseoTestnet`, `84532 → baseSepolia`.
+- **Proof encoding:**
+  ```
+  pA: [BigInt(pi_a[0]), BigInt(pi_a[1])]
+  pB: [[pi_b[0][1], pi_b[0][0]], [pi_b[1][1], pi_b[1][0]]]  // coordinates swapped
+  pC: [BigInt(pi_c[0]), BigInt(pi_c[1])]
+  proofBytes = encodeAbiParameters("uint256[2], uint256[2][2], uint256[2]", [pA, pB, pC])
+  ```
+- **Public inputs encoding:** `publicInputs = publicOutputs.map(o => toHex(BigInt(o), { size: 32 }))`.
+- **No-op on verification success:** The verifier contract reverts on failure; `readContract` not throwing is treated as `true`.
+- **Fix:** `verifyProofOnChain` now correctly returns the boolean result instead of always returning `true`.
+
+## Repo Evidence
+
+- Chain map, Paseo chain definition, ABI, and proof encoding:
+  - `src/chain/index.ts`
+- Boolean return fix:
+  - `src/blueprint.ts`
+
+## Demonstration
+
+```typescript
+import { verifyProofOnChain } from "@zk-email/sdk";
+
+// proof.blueprint.props.verifierContract = { chain: 420420417, address: "0x..." }
+const verified = await blueprint.verifyProofOnChain(proof);
+console.log(verified); // true if on-chain verification passed
+```
+
+## Status
+
+`Delivered`

--- a/docs/kusama-grant/milestone-3/02_noir_v2_compatibility.md
+++ b/docs/kusama-grant/milestone-3/02_noir_v2_compatibility.md
@@ -1,0 +1,50 @@
+# 02 - Noir v2.0.0 Proof Output Compatibility
+
+Deliverable mapping: Milestone 3, Noir v2.0.0 Proof Output Compatibility.
+
+## What was delivered
+
+The SDK was updated to parse and verify Noir proof outputs that match the `zkemail.nr` v2.0.0 public output layout, which introduces a new `pubkey_redc_hash` field.
+
+### Public output layout change
+
+`zkemail.nr` v2.0.0 adds a Barrett reduction precomputed value (`redc_param`) hash as a second public output, shifting all subsequent fields by one:
+
+| Index | v1.x | v2.0.0 |
+| --- | --- | --- |
+| 0 | `pubkey_modulus_hash` | `pubkey_modulus_hash` |
+| 1 | `email_nullifier` | `pubkey_redc_hash` *(new)* |
+| 2 | `header_hash[0]` | `email_nullifier` |
+| 3 | `header_hash[1]` | `header_hash[0]` |
+| 4 | `prover_address` | `header_hash[1]` |
+| 5 | *(first regex output)* | `prover_address` |
+| 6+ | — | *(first regex output)* |
+
+`publicOutputIterator` in `parseNoirPublicOutputs` was bumped from `5` to `6` to account for this.
+
+### Noir pubkey verification
+
+`verifyPubKey` in `src/utils/index.ts` was split into separate paths for Circom and Noir:
+
+- **Circom path (unchanged):** Uses Poseidon hash over 121-bit RSA chunks (17 limbs).
+- **Noir path (new):** Uses `hashRSAPublicKey()` from `@zk-email/zkemail-nr`, which hashes the modulus over **120-bit limbs** (9 limbs for RSA-1024, 18 limbs for RSA-2048). A helper `bigIntToLimbs(num, bitsPerLimb, numLimbs)` converts the modulus BigInt to the expected limb array. Dummy `redc` limbs are passed since only the modulus hash is needed for verification.
+
+## Implementation Notes
+
+- **Public output parsing:** [`src/prover/noir/index.ts`](../../../src/prover/noir/index.ts) — `parseNoirPublicOutputs`, `publicOutputIterator = 6`.
+- **Pubkey verification split:** [`src/utils/index.ts`](../../../src/utils/index.ts) — separate `if (zkFramework === ZkFramework.Circom)` and `if (zkFramework === ZkFramework.Noir)` blocks.
+- **Limb conversion:** `bigIntToLimbs(num, 120, numLimbs)` extracts little-endian 120-bit limbs from the RSA modulus BigInt.
+- **Dependency added:** `@zk-email/zkemail-nr@^2.0.0` in `package.json`.
+
+## Repo Evidence
+
+- Public output iterator and layout:
+  - `src/prover/noir/index.ts` (`parseNoirPublicOutputs`)
+- Noir pubkey verification and limb splitting:
+  - `src/utils/index.ts` (`verifyPubKey`, `bigIntToLimbs`)
+- Unit tests updated for new layout:
+  - `unit_tests/parseNoirPublicOutputs.test.ts`
+
+## Status
+
+`Delivered`


### PR DESCRIPTION
## Summary

- Adds `docs/kusama-grant/` delivery evidence for Kusama grant Milestone 3 (SDK scope)
- Documents multi-chain on-chain verification support and Noir v2.0.0 proof output compatibility

## Changes

- `docs/kusama-grant/README.md` — index
- `docs/kusama-grant/milestone-3/00_overview.md` — milestone overview
- `docs/kusama-grant/milestone-3/01_multi_chain_verification.md` — new `verify(bytes, bytes32[])` ABI, Paseo chain, viem encoding, snarkjs removal
- `docs/kusama-grant/milestone-3/02_noir_v2_compatibility.md` — new `pubkey_redc_hash` output field, 120-bit limb Noir pubkey hashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-chain on-chain verification support across Ethereum Sepolia, Paseo Testnet, and Base Sepolia
  * Noir v2.0.0 proof output compatibility

* **Documentation**
  * Added Kusama grant milestone documentation for Milestone 3 deliverables

* **Tests**
  * Added integration tests for blueprint submission and regex validation

* **Chores**
  * Updated SDK version to 1.4.1-3
  * Enhanced WebAssembly handling and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->