### PR TITLE
chore: disable/remove legacy non-working options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Blueprint, BlueprintProps, ListBlueprintsOptions } from "./blueprint";
+import { Blueprint, BlueprintProps, ListBlueprintsOptions, ZkFramework } from "./blueprint";
 import { BlueprintGroup } from "./blueprintGroup";
 import { Proof } from "./proof";
 import { BlueprintGroupProps } from "./types/blueprintGroup";
@@ -50,6 +50,13 @@ export const initZkEmailSdk = (sdkOptions?: SdkOptions) => {
     createBlueprint(props: BlueprintProps) {
       if (!sdkOptions && !sdkOptions!.auth) {
         throw new Error("You need to specify options.auth to use createBlueprint");
+      }
+      const disallowedFrameworks = [ZkFramework.Sp1, ZkFramework.Noir];
+      if (props.clientZkFramework && disallowedFrameworks.includes(props.clientZkFramework)) {
+        throw new Error("Only ZkFramework.Circom is currently supported for clientZkFramework");
+      }
+      if (props.serverZkFramework && disallowedFrameworks.includes(props.serverZkFramework)) {
+        throw new Error("Only ZkFramework.Circom is currently supported for serverZkFramework");
       }
       const blueprint = new Blueprint(props, baseUrl, sdkOptions!.auth);
       return blueprint;

--- a/src/prover/index.ts
+++ b/src/prover/index.ts
@@ -50,11 +50,8 @@ export abstract class AbstractProver implements IProver {
       throw new Error("Invalid blueprint: must be an instance of Blueprint class");
     }
     logger.debug("blueprint.props.clientZkFramework!: ", blueprint.props.clientZkFramework!);
-    if (
-      options?.isLocal &&
-      ![ZkFramework.Circom, ZkFramework.Noir].includes(blueprint.props.clientZkFramework!)
-    ) {
-      throw new Error("Local proving is currently only supported using Circom");
+    if (options?.isLocal) {
+      throw new Error("Local proving is currently disabled; only remote proving is supported");
     }
 
     this.blueprint = blueprint;


### PR DESCRIPTION
## Summary
- Reject `ZkFramework.Sp1` and `ZkFramework.Noir` in `createBlueprint()` for both `clientZkFramework` and `serverZkFramework` - only Circom is currently supported
- Reject `isLocal: true` in `createProver()` - only remote proving is currently supported

Mirrors registry's equivalent restriction (zkemail/registry#313), which hid these same options from the blueprint creation and proof generation UI. Existing Noir/SP1 blueprints and their remote proving still work; this only blocks creating new ones and blocks local proving entirely.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test:integration` - 2 pass, 0 fail (unaffected, doesn't touch these paths)
- [x] Verified `createBlueprint({ serverZkFramework: Sp1 })` and `createBlueprint({ clientZkFramework: Noir })` throw
- [x] Verified `createBlueprint({ serverZkFramework: Circom, clientZkFramework: Circom })` does not throw
- [x] Verified `createProver({ isLocal: true })` throws, `createProver({ isLocal: false })` does not