### PR TITLE
fix: real proof generation broken by relayer-utils version bump

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@azure/msal-browser": "^4.5.1",
         "@mach-34/noir-bignum-paramgen": "^1.1.2",
         "@peculiar/webcrypto": "^1.5.0",
-        "@zk-email/relayer-utils": "0.4.67-alpha.1",
+        "@zk-email/relayer-utils": "0.4.66-18",
         "@zk-email/snarkjs": "^0.0.1",
         "ethers": "^6.13.4",
         "jszip": "^3.10.1",
@@ -230,7 +230,7 @@
 
     "@types/pg": ["@types/pg@8.20.3", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-4Tvg+HO6+oQaAkpT8GTYoSExzpGGZz532GXgbbCElWJQeQdMozBWxEKNBhJJpHFjWXsMxqPbyypvj/89FWNoSQ=="],
 
-    "@zk-email/relayer-utils": ["@zk-email/relayer-utils@0.4.67-alpha.1", "", {}, "sha512-e3vY9/rLMTiIaw5Rf4QEhbo2It/DeAep166eKAhyyyuKDKN5BeDR7YDYr+2Uz5yUZLPhj57Kkw48E0bvFDuYcQ=="],
+    "@zk-email/relayer-utils": ["@zk-email/relayer-utils@0.4.66-18", "", {}, "sha512-uWznGyFs3yiaZHLlwdHiH/Ao1jETHeIEF4Qfrkl6MMZbAEeXEHJiMTldCn7mkGnks3pCG/Rv2nBU1vK1752IBQ=="],
 
     "@zk-email/snarkjs": ["@zk-email/snarkjs@0.0.1", "", { "dependencies": { "@iden3/binfileutils": "0.0.12", "bfj": "^7.0.2", "blake2b-wasm": "^2.4.0", "circom_runtime": "0.1.28", "ejs": "^3.1.6", "fastfile": "0.0.20", "ffjavascript": "0.3.1", "js-sha3": "^0.8.0", "logplease": "^1.2.15", "r1csfile": "0.0.48" }, "bin": { "snarkjs": "build/cli.cjs" } }, "sha512-QJ2GfP4C5AW7gAshxHeToLwLdRy1hMiTMaL9AqJiW9hQ2zDD5gMFdav79q7Jwm3h42kzU3A+Na9zqpDr3Iue2w=="],
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@azure/msal-browser": "^4.5.1",
     "@mach-34/noir-bignum-paramgen": "^1.1.2",
     "@peculiar/webcrypto": "^1.5.0",
-    "@zk-email/relayer-utils": "0.4.67-alpha.1",
+    "@zk-email/relayer-utils": "0.4.66-18",
     "@zk-email/snarkjs": "^0.0.1",
     "ethers": "^6.13.4",
     "jszip": "^3.10.1",

--- a/src/relayerUtils.ts
+++ b/src/relayerUtils.ts
@@ -293,13 +293,8 @@ export async function generateProofInputs(
         parts: dcr.parts.map((p) => {
           const isPublic = p.isPublic ?? (p as any).is_public ?? false;
           const regexDef = p.regexDef ?? (p as any).regex_def ?? "";
-          const maxLength = p.maxLength ?? (p as any).max_length;
 
-          if (isPublic) {
-            return [regexDef, maxLength ?? 256];
-          } else {
-            return regexDef;
-          }
+          return { isPublic, regexDef };
         }),
         provingFramework: "circom",
       };


### PR DESCRIPTION
## Summary
- `generateProofInputs()`'s decomposed-regex part mapping returned a bare string for non-public parts and a `[regexDef, maxLength]` tuple for public ones. Neither matches what `@zk-email/relayer-utils`'s WASM binding actually expects: a single struct `{ isPublic, regexDef }` for every part (confirmed by inspecting the WASM binary's embedded strings - `RegexPartConfig`, 2 fields, camelCase/snake_case aliases, no `maxLength`)
- This was masked until now because `0.4.67-alpha.1`'s predecessor (`0.4.66-18` - what registry's deployed SDK and sdk-images both still use) accepted an untagged enum with a lenient legacy fallback variant that tolerated both wrong shapes. `0.4.67-alpha.1` dropped that fallback
- The version bump to `0.4.67-alpha.1` (11bf30e, 2025-09-14, on `feat/new-compiler`) predates today entirely - it just never got exercised by a real end-to-end proof generation until now, and only reached `staging` today via the #92 squash-merge
- Fixes both: downgrades back to `0.4.66-18` to match what's actually proven working in production, and fixes the part-shape bug itself so this doesn't silently break again on a future version bump

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test:integration` - 2 pass, 0 fail
- [x] Generated a real, fresh proof against the `kusama_grant_paseo_e2e` blueprint (not a mock or existing proof): generation succeeded (~210s), `publicData` decoded correctly (`{ email_sender: ["info@x.com"] }`), and the proof verified on-chain (`verifyProofOnChain` returned `true`)