### PR TITLE
fix: alias node:crypto to crypto-browserify, not just crypto

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
       querystring: path.resolve("node_modules/rollup-plugin-node-polyfills/polyfills/qs"),
       url: path.resolve("node_modules/rollup-plugin-node-polyfills/polyfills/url"),
       crypto: "crypto-browserify",
+      "node:crypto": "crypto-browserify",
       http: path.resolve("node_modules/rollup-plugin-node-polyfills/polyfills/http"),
       https: path.resolve("node_modules/rollup-plugin-node-polyfills/polyfills/http"),
       os: path.resolve("node_modules/rollup-plugin-node-polyfills/polyfills/os"),


### PR DESCRIPTION
## Summary
- Only the bare `crypto` specifier was aliased to `crypto-browserify`; the `node:crypto` (ESM) form fell through unaliased
- That split - the same dependency resolving two different ways depending on specifier form - causes Rollup to bundle crypto-browserify's cipher module inconsistently, sometimes as an eager IIFE instead of the expected lazy CJS wrapper, which crashes as `X.getCiphers is not a function` under Next.js/Turbopack SSR (registry's app)
- This exact bug was hit and fixed before during the SP1 v6 upgrade (same symptom, same root cause), but the `node:crypto` alias never actually landed in this `vite.config.ts` - the #98 relayer-utils downgrade just happened to shift bundling enough to re-trigger the same underlying gap

## Test plan
- [x] `bun run typecheck` passes
- [x] Rebuilt, copied `dist/` into a local `registry` checkout's installed `@zk-email/sdk`, ran a real `next build` + `next start`, and confirmed the previously-crashing routes (e.g. `/[blueprintId]/versions`) no longer throw