### PR TITLE
fix: export verifyProofOnChain from the SDK's public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export type { ValidationErrors } from "./blueprintValidation";
 
 // Exports that don't need initialization or options
 export { startJsonFileDownload, getDKIMSelector } from "./utils";
+export { verifyProofOnChain } from "./chain";
 export { logger } from "./utils/logger";
 export type { LogLevel, LoggingOptions } from "./types/sdk";
 export {


### PR DESCRIPTION
## Summary
- \`verifyProofOnChain\` (\`src/chain/index.ts\`) is implemented and used internally by \`Blueprint.verifyProofOnChain\`, but was never actually exported from the package - consumers had no working way to call it directly
- The instance method wrapper (\`blueprint.verifyProofOnChain(proof)\`) currently discards the standalone function's real result and always resolves \`true\` unless an exception is thrown (a separate, already-tracked bug, not touched here). The standalone function itself resolves the real boolean correctly (\`true\`/\`false\`)
- This just exposes the already-correct function; found while writing a public how-to doc that needed to call it directly

## Test plan
- [x] \`bun run typecheck\` passes
- [x] Ran a real script importing \`verifyProofOnChain\` from \`./src\`, generating a real proof and verifying it on-chain - resolved \`true\` correctly