### PR TITLE
fix: propagate the real verification result from blueprint.verifyProofOnChain

### DIFF
--- a/src/blueprint.ts
+++ b/src/blueprint.ts
@@ -589,12 +589,11 @@ export class Blueprint {
    */
   async verifyProofOnChain(proof: Proof): Promise<boolean> {
     try {
-      await verifyProofOnChain(proof);
+      return await verifyProofOnChain(proof);
     } catch (err) {
       logger.error("Failed to verify proof on chain: ", err);
       return false;
     }
-    return true;
   }
 
   /**

--- a/tests/integration/kusama/verifyProofOnChain.test.ts
+++ b/tests/integration/kusama/verifyProofOnChain.test.ts
@@ -25,4 +25,21 @@ describe("On chain verification against Paseo (kusama_grant_paseo_e2e)", () => {
     const result = await verifyProofOnChain(proof);
     expect(result).toBe(false);
   });
+
+  // These go through proof.blueprint.verifyProofOnChain, the method the registry UI actually
+  // calls, rather than the standalone import above.
+  test("blueprint.verifyProofOnChain verifies a real proof against the deployed Paseo verifier", async () => {
+    const proof = await sdk.getProof(PROOF_ID);
+    const result = await proof.blueprint.verifyProofOnChain(proof);
+    expect(result).toBe(true);
+  });
+
+  test("blueprint.verifyProofOnChain rejects a tampered proof", async () => {
+    const proof = await sdk.getProof(PROOF_ID);
+    // @ts-ignore
+    proof.props.proofData.pi_a[0] = "9999999999" + proof.props.proofData.pi_a[0].slice(10);
+
+    const result = await proof.blueprint.verifyProofOnChain(proof);
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- `Blueprint.verifyProofOnChain` discarded the standalone `verifyProofOnChain` call's return value and returned `true` unless the SDK itself threw, so a tampered proof that correctly reverts on-chain still reported success through the method the registry UI actually calls (`ProofRow.tsx`, `proofs/[proofId]/page.tsx`).
- Every other verify-family method in the SDK (`verifyProof`, `Blueprint.verifyProof`, `Proof.verify`, `verifyNoirProof`, the standalone `verifyProofOnChain`, and `Proof.verifyOnChain` which wraps the identical standalone function) propagates the real pass/fail result. This method was the sole exception, tracing back to a debug scaffold from its original 2024-10-20 introduction that was never wired to a `return`.
- Fix: return the standalone call's result directly instead of discarding it.

## Test plan
- [x] Added two new cases to `tests/integration/kusama/verifyProofOnChain.test.ts`, going through `blueprint.verifyProofOnChain` (not just the standalone import): valid proof asserts `true`, tampered proof asserts `false`.
- [x] Confirmed the new tampered-proof case fails without the fix and passes with it (reverted the fix locally, reran, restored, reran again).
- [x] Full `test:integration` suite passes (4/4).
- [x] `tsc --noEmit` clean.