### PR TITLE
chore: add workflow_dispatch trigger to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Adds a \`workflow_dispatch\` trigger to \`ci.yml\` alongside the existing \`pull_request\` trigger.
- Split out from #104, where it was added as a diagnostic while investigating why \`pull_request\`-triggered CI runs aren't firing for this repo (confirmed via manual dispatch that Actions itself works fine, isolating the issue to the \`pull_request\` event specifically).
- Useful going forward regardless of that issue: lets CI be re-run manually from the Actions tab without needing a dummy commit or PR close/reopen.